### PR TITLE
Fix aspect-ratio on parent affecting children

### DIFF
--- a/styles/about.css
+++ b/styles/about.css
@@ -10,8 +10,8 @@ video {
 }
 
 .container {
-	width: 800px;
-	height: 600px;
+	width: 80%;
+	aspect-ratio: 4 / 3;
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -36,8 +36,12 @@ img.mimage {
 	aspect-ratio: 1 / 1;
 }
 
-.content {
-	text-align: justify;
+nav {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	text-align: center;
+	gap: 10px;
 }
 
 a {
@@ -62,4 +66,30 @@ a:hover {
 
 a:active {
 	color: #e4d5b7;
+}
+
+@media screen and (min-width: 1024px) {
+	.container {
+		width: 600px;
+		aspect-ratio: 4 / 3;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -55%);
+		display: flex;
+		flex-direction: column;
+	}
+}
+
+@media screen and (min-width: 1280px) {
+	.container {
+		width: 800px;
+		aspect-ratio: 4 / 3;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -55%);
+		display: flex;
+		flex-direction: column;
+	}
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -10,12 +10,12 @@ video {
 }
 
 .container {
-	width: 80%;
-	aspect-ratio: 4 / 3;
+	width: 300px;
+	height: 225px;
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	transform: translate(-50%, -55%);
+	transform: translate(-50%, -60%);
 	display: flex;
 	flex-direction: column;
 }
@@ -64,8 +64,8 @@ a:active {
 
 @media screen and (min-width: 1024px) {
 	.container {
-		width: 640px;
-		aspect-ratio: 4 / 3;
+		width: 600px;
+		height: 450px;
 		position: absolute;
 		top: 50%;
 		left: 50%;
@@ -78,7 +78,7 @@ a:active {
 @media screen and (min-width: 1280px) {
 	.container {
 		width: 800px;
-		aspect-ratio: 4 / 3;
+		height: 600px;
 		position: absolute;
 		top: 50%;
 		left: 50%;


### PR DESCRIPTION
`aspect-ratio` was applied to `.container`, causing the aspect-ratio to be the same on all children elements. This has been fixed on the homepage, but not on others. If it looks good, I'll apply the change to the other pages.