### PR TITLE
Add favicon support for iOS devices

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,6 +9,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap" rel="stylesheet" />
 		<link rel="icon" href="images/favicon.svg" />
+		<link rel="apple-touch-icon" href="images/favicon.svg" />
 	</head>
 	<body>
 		<a class="homebutton" href="index.html">quinncubostar</a>

--- a/blog.html
+++ b/blog.html
@@ -9,6 +9,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap" rel="stylesheet" />
 		<link rel="icon" href="images/favicon.svg" />
+		<link rel="apple-touch-icon" href="images/favicon.svg" />
 	</head>
 	<body>
 		<a class="homebutton" href="index.html">quinncubostar</a>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap" rel="stylesheet" />
 		<link rel="icon" href="images/favicon.svg" />
+		<link rel="apple-touch-icon" href="images/favicon.svg" />
 		<meta name="description" content="The little shop of Quinn Arbolante (Cubostar) held at a corner of the internet." />
 	</head>
 	<body>


### PR DESCRIPTION
Adds `<link rel="apple-touch-icon" href="apple-touch-icon.png">` to all pages' heads for iOS device favicon support.